### PR TITLE
Fix error in casted parameter

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "easyinspect/economic",
+    "name": "ramlev/economic",
     "description": "Wrapper to call economic API.",
     "type": "library",
     "license": "open source",
@@ -7,6 +7,10 @@
         {
             "name": "Mikkel Schou",
             "email": "mbs@easyinspect.net"
+        },
+        {
+            "name": "Hasse Ramlev Wilson",
+            "email": "hasse@ramlev.dk"
         }
     ],
    "require": {

--- a/composer.json
+++ b/composer.json
@@ -11,6 +11,7 @@
 	{
             "name": "Hasse Ramlev Wilson",
             "email": "hasse@ramlev.dk"
+	}
     ],
    "require": {
         "php": ">=7.1",

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "easyinspect/economic",
+    "name": "ramlev/economic",
     "description": "Wrapper to call economic API.",
     "type": "library",
     "license": "MIT",
@@ -7,7 +7,10 @@
         {
             "name": "Mikkel Schou",
             "email": "mbs@easyinspect.net"
-        }
+        },
+	{
+            "name": "Hasse Ramlev Wilson",
+            "email": "hasse@ramlev.dk"
     ],
    "require": {
         "php": ">=7.1",

--- a/src/Models/Customer.php
+++ b/src/Models/Customer.php
@@ -716,7 +716,7 @@ class Customer
     }
 
     /** @return bool */
-    public function getBarred() : ?boolean
+    public function getBarred() : ?bool
     {
         return $this->barred;
     }
@@ -725,7 +725,7 @@ class Customer
      * @param bool $barred
      * @return $this
      */
-    public function setBarred(?boolean $barred)
+    public function setBarred(?bool $barred)
     {
         $this->barred = $barred;
 

--- a/src/Models/Customer.php
+++ b/src/Models/Customer.php
@@ -736,7 +736,7 @@ class Customer
     }
 
     /** @return bool */
-    public function getBarred() : ?boolean
+    public function getBarred() : ?bool
     {
         return $this->barred;
     }
@@ -745,7 +745,7 @@ class Customer
      * @param bool $barred
      * @return $this
      */
-    public function setBarred(?boolean $barred)
+    public function setBarred(?bool $barred)
     {
         $this->barred = $barred;
 


### PR DESCRIPTION
Boolean is called bool when casting, used in setBarred() and getBarred() need to be fixed to prevent from throwing an exception